### PR TITLE
WIP: Improve readability and fix failing tests

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class AppTest extends Orchestra\Testbench\TestCase
 {
     protected $app;
@@ -46,15 +45,14 @@ class AppTest extends Orchestra\Testbench\TestCase
 
     public function testFormMaker()
     {
-        $kernel = $this->app['Illuminate\Contracts\Console\Kernel'];
-        $status = $kernel->handle(
+         $this->app['Illuminate\Contracts\Console\Kernel']->handle(
             $input = new \Symfony\Component\Console\Input\ArrayInput([
-                'command' => 'crudmaker:make',
+                'command' => 'crudmaker:new',
                 '--no-interaction' => true
             ]),
             $output = new \Symfony\Component\Console\Output\BufferedOutput
         );
 
-        $this->assertTrue(strpos($output->fetch(), 'Not enough arguments (missing: "table")') > 0);
+        $this->assertContains('Not enough arguments (missing: "table")', $output->fetch());
     }
 }

--- a/tests/CrudGeneratorTest.php
+++ b/tests/CrudGeneratorTest.php
@@ -12,10 +12,10 @@ class CrudGeneratorTest extends PHPUnit_Framework_TestCase
     {
         $this->generator = new CrudGenerator();
         $this->config = [
-            'framework'                  => 'laravel',
+            'framework'                 => 'laravel',
             'bootstrap'                  => false,
             'semantic'                   => false,
-            'template_source'            => '',
+            'template_source'            => __DIR__.'/../src/Templates/Laravel',
             '_sectionPrefix_'            => '',
             '_sectionTablePrefix_'       => '',
             '_sectionRoutePrefix_'       => '',
@@ -46,64 +46,73 @@ class CrudGeneratorTest extends PHPUnit_Framework_TestCase
             '_lower_casePlural_'         => str_plural(strtolower('testTable')),
             '_camel_case_'               => ucfirst(camel_case('testTable')),
             '_camel_casePlural_'         => str_plural(camel_case('testTable')),
-            'template_source'            => __DIR__.'/../src/Templates/Laravel',
         ];
     }
 
     public function testApiGenerator()
     {
         $this->crud = vfsStream::setup("Http/Controllers/Api");
+
         $this->generator->createApi($this->config, false);
-        $this->assertTrue($this->crud->hasChild('Http/Controllers/Api/TestTableController.php'));
         $contents = $this->crud->getChild('Http/Controllers/Api/TestTableController.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableController extends Controller') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Http/Controllers/Api/TestTableController.php'));
+        $this->assertContains('class TestTableController extends Controller', $contents->getContent());
     }
 
     public function testControllerGenerator()
     {
         $this->crud = vfsStream::setup("Http/Controllers");
         $this->generator->createController($this->config);
+
         $this->assertTrue($this->crud->hasChild('Http/Controllers/TestTableController.php'));
         $contents = $this->crud->getChild('Http/Controllers/TestTableController.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableController extends Controller') !== false);
+
+        $this->assertContains('class TestTableController extends Controller', $contents->getContent());
     }
 
     public function testRepositoryGenerator()
     {
         $this->crud = vfsStream::setup("Repositories/TestTable");
+
         $this->generator->createRepository($this->config);
-        $this->assertTrue($this->crud->hasChild('Repositories/TestTable/TestTableRepository.php'));
         $contents = $this->crud->getChild('Repositories/TestTable/TestTableRepository.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepository') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Repositories/TestTable/TestTableRepository.php'));
+        $this->assertContains('class TestTableRepository', $contents->getContent());
     }
 
     public function testRequestGenerator()
     {
         $this->crud = vfsStream::setup("Http/Requests");
+
         $this->generator->createRequest($this->config);
-        $this->assertTrue($this->crud->hasChild('Http/Requests/TestTableRequest.php'));
         $contents = $this->crud->getChild('Http/Requests/TestTableRequest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRequest') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Http/Requests/TestTableRequest.php'));
+        $this->assertContains('class TestTableRequest', $contents->getContent());
     }
 
     public function testServiceGenerator()
     {
         $this->crud = vfsStream::setup("Services");
+
         $this->generator->createService($this->config);
-        $this->assertTrue($this->crud->hasChild('Services/TestTableService.php'));
         $contents = $this->crud->getChild('Services/TestTableService.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableService') !== false);
+
+        $this->assertTrue($this->crud->hasChild('Services/TestTableService.php'));
+        $this->assertContains('class TestTableService', $contents->getContent());
     }
 
     public function testRoutesGenerator()
     {
         $this->crud = vfsStream::setup("Http");
         file_put_contents(vfsStream::url('Http/routes.php'), 'test');
+
         $this->generator->createRoutes($this->config, false);
         $contents = $this->crud->getChild('Http/routes.php');
-        $this->assertTrue(strpos($contents->getContent(), 'TestTableController') !== false);
 
-        // Ensure Search Route specification exists and Controller and Action remain
+        $this->assertContains('TestTableController', $contents->getContent());
         $this->assertContains('\'as\' => \'testtables.search\'', $contents->getContent());
         $this->assertContains('\'uses\' => \'TestTableController@search\'', $contents->getContent());
     }
@@ -111,43 +120,47 @@ class CrudGeneratorTest extends PHPUnit_Framework_TestCase
     public function testViewsGenerator()
     {
         $this->crud = vfsStream::setup("resources/views");
+
         $this->generator->createViews($this->config);
-        $this->assertTrue($this->crud->hasChild('resources/views/testtables/index.blade.php'));
         $contents = $this->crud->getChild('resources/views/testtables/index.blade.php');
-        $this->assertTrue(strpos($contents->getContent(), '$testtable') !== false);
+
+        $this->assertTrue($this->crud->hasChild('resources/views/testtables/index.blade.php'));
+        $this->assertContains('$testtable', $contents->getContent());
     }
 
     public function testTestGenerator()
     {
         $this->crud = vfsStream::setup("tests");
+
         $this->assertTrue($this->generator->createTests($this->config, false));
 
-        $this->assertTrue($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
         $contents = $this->crud->getChild('tests/acceptance/TestTableAcceptanceTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableAcceptanceTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
+        $this->assertContains('class TestTableAcceptanceTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableRepositoryIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepositoryIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
+        $this->assertContains('class TestTableRepositoryIntegrationTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableServiceIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableServiceIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
+        $this->assertContains('class TestTableServiceIntegrationTest', $contents->getContent());
     }
 
     public function testTestGeneratorServiceOnly()
     {
         $this->crud = vfsStream::setup("tests");
+
         $this->assertTrue($this->generator->createTests($this->config, true));
 
         $this->assertFalse($this->crud->hasChild('tests/acceptance/TestTableAcceptanceTest.php'));
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableRepositoryIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableRepositoryIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableRepositoryIntegrationTest.php'));
+        $this->assertContains('class TestTableRepositoryIntegrationTest', $contents->getContent());
 
-        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
         $contents = $this->crud->getChild('tests/integration/TestTableServiceIntegrationTest.php');
-        $this->assertTrue(strpos($contents->getContent(), 'class TestTableServiceIntegrationTest') !== false);
+        $this->assertTrue($this->crud->hasChild('tests/integration/TestTableServiceIntegrationTest.php'));
+        $this->assertContains('class TestTableServiceIntegrationTest', $contents->getContent());
     }
 }

--- a/tests/TableServiceTest.php
+++ b/tests/TableServiceTest.php
@@ -47,21 +47,23 @@ class TableServiceTest extends PHPUnit_Framework_TestCase
     public function testPrepareTableDefinition()
     {
         $table = "id:increments,name:string,details:text";
+
         $result = $this->service->prepareTableDefinition($table);
 
-        $this->assertTrue((bool) strstr($result, 'id'));
-        $this->assertTrue((bool) strstr($result, 'name'));
-        $this->assertTrue((bool) strstr($result, 'details'));
+        $this->assertContains('id', $result);
+        $this->assertContains('name', $result);
+        $this->assertContains('details', $result);
     }
 
     public function testPrepareTableExample()
     {
         $table = "id:increments,name:string,details:text,created_on:dateTime";
+
         $result = $this->service->prepareTableExample($table);
 
-        $this->assertTrue((bool) strstr($result, 'laravel'));
-        $this->assertTrue((bool) strstr($result, 'I am Batman'));
-        $this->assertTrue((bool) strstr($result, '1'));
+        $this->assertContains('laravel', $result);
+        $this->assertContains('I am Batman', $result);
+        $this->assertContains('1', $result);
     }
 
 }

--- a/tests/ValidatorServiceTest.php
+++ b/tests/ValidatorServiceTest.php
@@ -60,8 +60,8 @@ class ValidatorServiceTest extends AppTest
             ->with('migration')
             ->andReturn(true)
             ->getMock();
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateSchema($this->command);
     }
 
@@ -78,6 +78,7 @@ class ValidatorServiceTest extends AppTest
             ->andReturn(true);
 
         $test = $this->validator->validateSchema($this->command);
+
         $this->assertTrue($test);
     }
 
@@ -86,8 +87,8 @@ class ValidatorServiceTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('ui')
             ->andReturn('purecss');
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateSchema($this->command);
     }
 
@@ -107,6 +108,7 @@ class ValidatorServiceTest extends AppTest
             ->andReturn(true);
 
         $test = $this->validator->validateOptions($this->command);
+
         $this->assertTrue($test);
     }
 
@@ -124,8 +126,8 @@ class ValidatorServiceTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('migration')
             ->andReturn(false);
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateOptions($this->command);
     }
 
@@ -143,8 +145,8 @@ class ValidatorServiceTest extends AppTest
         $this->command->shouldReceive('option')
             ->with('migration')
             ->andReturn(false);
-
         $this->setExpectedException('Exception');
+
         $this->validator->validateOptions($this->command);
     }
 }


### PR DESCRIPTION
Made the tests somewhat better readable by for instance using assertContains instead of assertTrue(strpos(...) !== false). Also, changed the order of parameters in some cases, so the expected output is the first parameters. Both help in showing more accurate reasons why a test fails.

Also changed the test methods to a sort of 'given when then' format, to improve readability. And restructured the DatabaseGeneratorTest.

Also fixed AppTest@testFormMaker, ValidatorServiceTest@testFormMaker and all DatabaseGeneratorTest methods, since they were failing.