### PR TITLE
Fixed bug with mis-labelled Controller for search routes

### DIFF
--- a/src/Templates/Laravel/ApiRoutes.txt
+++ b/src/Templates/Laravel/ApiRoutes.txt
@@ -6,5 +6,5 @@
 */
 
 Route::group(['middleware' => 'jwt.auth'], function () {
-    Route::resource('v1/_sectionRoutePrefix__lower_casePlural_', 'Api\_sectionNamespace__camel_case_Controller', ['as' => 'api']);
+    Route::resource('v1/_sectionRoutePrefix__lower_casePlural_', 'Api\_sectionNamespace__ucCamel_casePlural_Controller', ['as' => 'api']);
 });

--- a/src/Templates/Laravel/Routes.txt
+++ b/src/Templates/Laravel/Routes.txt
@@ -8,5 +8,5 @@
 Route::resource('_lower_casePlural_', '_ucCamel_casePlural_Controller', ['except' => ['show']]);
 Route::post('_sectionRoutePrefix__lower_casePlural_/search', [
     'as' => '_sectionPrefix__lower_casePlural_.search',
-    'uses' => '_camel_case_Controller@search'
+    'uses' => '_ucCamel_casePlural_Controller@search'
 ]);

--- a/tests/Generators/CrudSectionGeneratorTest.php
+++ b/tests/Generators/CrudSectionGeneratorTest.php
@@ -113,9 +113,9 @@ class CrudSectionGeneratorTest extends PHPUnit_Framework_TestCase
         $this->generator->createRoutes($this->config, false);
         $contents = $this->crud->getChild('Http/routes.php');
 
-        $this->assertContains('TestTableController', $contents->getContent());
+        $this->assertContains('TestTablesController', $contents->getContent());
         $this->assertContains('\'as\' => \'superman.testtables.search\'', $contents->getContent());
-        $this->assertContains('\'uses\' => \'TestTableController@search\'', $contents->getContent());
+        $this->assertContains('\'uses\' => \'TestTablesController@search\'', $contents->getContent());
     }
 
     public function testViewsGenerator()

--- a/tests/Generators/CrudSingleGeneratorTest.php
+++ b/tests/Generators/CrudSingleGeneratorTest.php
@@ -112,9 +112,9 @@ class CrudSingleGeneratorTest extends PHPUnit_Framework_TestCase
         $this->generator->createRoutes($this->config, false);
         $contents = $this->crud->getChild('Http/routes.php');
 
-        $this->assertContains('TestTableController', $contents->getContent());
+        $this->assertContains('TestTablesController', $contents->getContent());
         $this->assertContains('\'as\' => \'testtables.search\'', $contents->getContent());
-        $this->assertContains('\'uses\' => \'TestTableController@search\'', $contents->getContent());
+        $this->assertContains('\'uses\' => \'TestTablesController@search\'', $contents->getContent());
     }
 
     public function testViewsGenerator()

--- a/tests/Services/CrudServiceTest.php
+++ b/tests/Services/CrudServiceTest.php
@@ -95,7 +95,7 @@ class CrudServiceTest extends TestCase
 
         $this->assertTrue($crud->hasChild('Http/Controllers/TestTablesController.php'));
         $this->assertContains('class TestTablesController', $controllerContents->getContent());
-        $this->assertContains('TestTableController', $routesContents->getContent());
+        $this->assertContains('TestTablesController', $routesContents->getContent());
     }
 
     public function testGenerateAPI()
@@ -109,6 +109,6 @@ class CrudServiceTest extends TestCase
 
         $this->assertTrue($crud->hasChild('Http/Controllers/Api/TestTablesController.php'));
         $this->assertContains('class TestTablesController', $controllerContents->getContent());
-        $this->assertContains('TestTableController', $routesContents->getContent());
+        $this->assertContains('TestTablesController', $routesContents->getContent());
     }
 }


### PR DESCRIPTION
The `Route::post()` template used the singular controller name instead of plural, which is what the generated controller is actually called. I've fixed this.