### PR TITLE
AppNamespaceDetectorTrait renamed to DetectsApplicationNamespace

### DIFF
--- a/src/Console/TableCrudMaker.php
+++ b/src/Console/TableCrudMaker.php
@@ -3,14 +3,14 @@
 namespace Yab\CrudMaker\Console;
 
 use Exception;
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Yab\CrudMaker\Services\TableService;
 
 class TableCrudMaker extends Command
 {
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
 
     /**
      * The console command name.


### PR DESCRIPTION
AppNamespaceDetectorTrait renamed to DetectsApplicationNamespace as 5.4 to match change in 5.4 of laravel.

> php artisan ide-helper:generate
PHP Fatal error:  Trait 'Illuminate\Console\AppNamespaceDetectorTrait' not found in /Users/t/code/vaprobash/laravel/vendor/yab/crudmaker/src/Console/TableCrudMaker.php on line 13
PHP Stack trace:
PHP   1. {main}() /Users/t/code/vaprobash/laravel/artisan:0
PHP   2. Illuminate\Foundation\Console\Kernel->handle() /Users/t/code/vaprobash/laravel/artisan:35
PHP   3. Illuminate\Foundation\Console\Kernel->getArtisan() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:123
PHP   4. Illuminate\Console\Application->__construct() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:287
PHP   5. Illuminate\Console\Application->bootstrap() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:58
PHP   6. Illuminate\Support\ServiceProvider->Illuminate\Support\{closure}() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:111
PHP   7. Illuminate\Console\Application->resolveCommands() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Support/ServiceProvider.php:232
PHP   8. Illuminate\Console\Application->resolve() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:206
PHP   9. Illuminate\Foundation\Application->make() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Console/Application.php:192
PHP  10. Illuminate\Container\Container->make() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:702
PHP  11. Illuminate\Container\Container->build() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:565
PHP  12. ReflectionClass->__construct() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:681
PHP  13. spl_autoload_call() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:681
PHP  14. Composer\Autoload\ClassLoader->loadClass() /Users/t/code/vaprobash/laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:681
PHP  15. Composer\Autoload\includeFile() /Users/t/code/vaprobash/laravel/vendor/composer/ClassLoader.php:322
PHP  16. include() /Users/t/code/vaprobash/laravel/vendor/composer/ClassLoader.php:440


  [Symfony\Component\Debug\Exception\FatalErrorException]
  Trait 'Illuminate\Console\AppNamespaceDetectorTrait' not found