### PR TITLE
Make the Service generated more general for non-standard data

### DIFF
--- a/src/Templates/Laravel/Service.txt
+++ b/src/Templates/Laravel/Service.txt
@@ -60,7 +60,7 @@ class _camel_case_Service
      */
     public function search($payload)
     {
-        $query = $this->model->orderBy(_camel_case_::CREATED_AT, 'desc');
+        $query = $this->model->orderBy('created_at', 'desc');
         $query->where($this->model->primaryKey, 'LIKE', '%'.$payload.'%');
 
         $columns = Schema::getColumnListing('_lower_casePlural_');

--- a/src/Templates/Laravel/Service.txt
+++ b/src/Templates/Laravel/Service.txt
@@ -60,8 +60,8 @@ class _camel_case_Service
      */
     public function search($payload)
     {
-        $query = $this->model->orderBy('created_at', 'desc');
-        $query->where('id', 'LIKE', '%'.$payload.'%');
+        $query = $this->model->orderBy(_camel_case_::CREATED_AT, 'desc');
+        $query->where($this->model->primaryKey, 'LIKE', '%'.$payload.'%');
 
         $columns = Schema::getColumnListing('_lower_casePlural_');
 


### PR DESCRIPTION
When using CrudMaker on a legacy database we had to go through and change "id" in each file and change it to match the primary key in the legacy database. This issue can be resolved pretty easily by allowing people to just use the default variable in the model file. 

updated Service.txt to avoid column not found errors when id is not the default primary key. 

I had a commit to fix this same issue for the CREATED_AT constant value of a model, but after discussion with @mlantz it was decided that this is an edge case that should be left to people with that case to resolve. 

A simple fix for anyone wanting to fix that would be to either use `"model_name"::CREATED_AT`, or if you have timestamps set to false for a model, remove this line. 