### PR TITLE
Fixes comment interfering with with fillable array

### DIFF
--- a/src/Templates/Laravel/Model.txt
+++ b/src/Templates/Laravel/Model.txt
@@ -13,7 +13,8 @@ class _camel_case_ extends Model
     public $timestamps = true;
 
     public $fillable = [
-// _camel_case_ table data    ];
+// _camel_case_ table data    
+];
 
     public static $rules = [
         // create rules


### PR DESCRIPTION
One of the comments for the crudmaker model (`$fillable`) was commenting out the array closing brackets. This pull request fixes it.