### PR TITLE
Fix generated Request namespace in controller DocBlocks

### DIFF
--- a/src/Templates/Laravel/ApiController.txt
+++ b/src/Templates/Laravel/ApiController.txt
@@ -39,7 +39,7 @@ class _ucCamel_casePlural_Controller extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\_camel_case_Request  $request
+     * @param  _namespace_request_\_camel_case_Request  $request
      * @return \Illuminate\Http\Response
      */
     public function store(_camel_case_Request $request)
@@ -68,7 +68,7 @@ class _ucCamel_casePlural_Controller extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\_camel_case_Request  $request
+     * @param  _namespace_request_\_camel_case_Request  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */

--- a/src/Templates/Laravel/Controller.txt
+++ b/src/Templates/Laravel/Controller.txt
@@ -50,7 +50,7 @@ class _ucCamel_casePlural_Controller extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\_camel_case_CreateRequest  $request
+     * @param  _namespace_request_\_camel_case_CreateRequest  $request
      * @return \Illuminate\Http\Response
      */
     public function store(_camel_case_CreateRequest $request)
@@ -91,7 +91,7 @@ class _ucCamel_casePlural_Controller extends Controller
     /**
      * Update the _lower_casePlural_ in storage.
      *
-     * @param  \Illuminate\Http\_camel_case_UpdateRequest  $request
+     * @param  _namespace_request_\_camel_case_UpdateRequest  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */


### PR DESCRIPTION
CrudMaker is generating DocBlocks in controllers for `store()` and `update()` with the `\Illuminate\Http` namespace, when the Request classes are actually within the `_namespace_request_` (e.g., `\App\Http\Requests`) namespace. This changes those templates accordingly.